### PR TITLE
add ZeroQueryDict::iterator::operator-- for gcc8

### DIFF
--- a/src/prediction/zero_query_dict.h
+++ b/src/prediction/zero_query_dict.h
@@ -132,6 +132,17 @@ class ZeroQueryDict {
       return tmp;
     }
 
+    iterator &operator--() {
+      ptr_ -= kTokenByteSize;
+      return *this;
+    }
+
+    iterator operator--(int) {
+      const iterator tmp(ptr_, string_array_);
+      ptr_ -= kTokenByteSize;
+      return tmp;
+    }
+
     iterator &operator+=(ptrdiff_t n) {
       ptr_ += n * kTokenByteSize;
       return *this;


### PR DESCRIPTION
add `ZeroQueryDict::iterator::operator--` , otherwise gcc 8.x will complain like: https://fars.ee/DAiY
```
In file included from ../../engine/engine.cc:30:
In file included from /build/fcitx5-mozc-git/src/mozc/src/engine/engine.h:33:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/memory:62:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/bits/stl_algobase.h:66:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/bits/stl_iterator_base_funcs.h:183:2: error: cannot decrement value of type 'mozc::ZeroQueryDict::iterator'
        --__i;
        ^ ~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/bits/stl_iterator_base_funcs.h:206:12: note: in instantiation of function template specialization 'std::__advance<mozc::ZeroQueryDict::iterator, long>' requested here
      std::__advance(__i, __d, std::__iterator_category(__i));
           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/bits/stl_algo.h:2137:9: note: in instantiation of function template specialization 'std::advance<mozc::ZeroQueryDict::iterator, long>' requested here
          std::advance(__middle, __half);
               ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.1.0/../../../../include/c++/8.1.0/bits/stl_algo.h:2190:19: note: in instantiation of function template specialization 'std::__equal_range<mozc::ZeroQueryDict::iterator, unsigned long, __gnu_cxx::__ops::_Iter_less_val, __gnu_cxx::__ops::_Val_less_iter>' requested here
      return std::__equal_range(__first, __last, __val,
                  ^
/build/fcitx5-mozc-git/src/mozc/src/prediction/zero_query_dict.h:213:17: note: in instantiation of function template specialization 'std::equal_range<mozc::ZeroQueryDict::iterator, unsigned long>' requested here
    return std::equal_range(begin(), end(), iter.index());
                ^
1 error generated.
```