### PR TITLE
fix install_fcitx translation files

### DIFF
--- a/scripts/install_fcitx
+++ b/scripts/install_fcitx
@@ -3,7 +3,7 @@
 _bldtype="${_bldtype:-Debug}"
 PREFIX="${PREFIX:-/usr}"
 
-for mofile in "out_linux/${_bldtype}/gen/unix/fcitx/po/*.mo"
+for mofile in out_linux/${_bldtype}/gen/unix/fcitx/po/*.mo
 do
     filename=`basename $mofile`
     lang=${filename/.mo/}


### PR DESCRIPTION
the for expansion path was quoted so bash will not expand glob patterns inside string quotation. 