### PR TITLE
C++: replace uint usage with unsigned

### DIFF
--- a/src/gui/word_register_dialog/word_register_dialog.cc
+++ b/src/gui/word_register_dialog/word_register_dialog.cc
@@ -94,7 +94,7 @@ QString GetEnv(const char *envname) {
       return QString::fromUtf16(reinterpret_cast<const ushort *>(buffer.get()));
     } else {
       // This is a fallback just in case.
-      return QString::fromUcs4(reinterpret_cast<const uint *>(buffer.get()));
+      return QString::fromUcs4(reinterpret_cast<const unsigned *>(buffer.get()));
     }
   }
   return QLatin1String("");

--- a/src/unix/fcitx/surrounding_text_util.cc
+++ b/src/unix/fcitx/surrounding_text_util.cc
@@ -41,10 +41,10 @@
 namespace mozc {
 namespace fcitx {
 
-bool SurroundingTextUtil::GetSafeDelta(uint from, uint to, int32 *delta) {
+bool SurroundingTextUtil::GetSafeDelta(unsigned from, unsigned to, int32 *delta) {
   DCHECK(delta);
 
-  static_assert(sizeof(int64) >= sizeof(uint),
+  static_assert(sizeof(int64) >= sizeof(unsigned),
                 "int64 must be sufficient to store a guint value.");
   static_assert(sizeof(int64) == sizeof(llabs(0)),
                 "|llabs(0)| must returns a 64-bit integer.");
@@ -113,8 +113,8 @@ bool SearchAnchorPosForward(
     const std::string &surrounding_text,
     const std::string &selected_text,
     size_t selected_chars_len,
-    uint cursor_pos,
-    uint *anchor_pos) {
+    unsigned cursor_pos,
+    unsigned *anchor_pos) {
 
   ConstChar32Iterator iter(surrounding_text);
   // Move |iter| to cursor pos.
@@ -137,15 +137,15 @@ bool SearchAnchorPosBackward(
     const std::string &surrounding_text,
     const std::string &selected_text,
     size_t selected_chars_len,
-    uint cursor_pos,
-    uint *anchor_pos) {
+    unsigned cursor_pos,
+    unsigned *anchor_pos) {
   if (cursor_pos < selected_chars_len) {
     return false;
   }
 
   ConstChar32Iterator iter(surrounding_text);
   // Skip |iter| to (potential) anchor pos.
-  const uint skip_count = cursor_pos - selected_chars_len;
+  const unsigned skip_count = cursor_pos - selected_chars_len;
   DCHECK_LE(skip_count, cursor_pos);
   if (!Skip(&iter, skip_count)) {
     return false;
@@ -164,8 +164,8 @@ bool SearchAnchorPosBackward(
 bool SurroundingTextUtil::GetAnchorPosFromSelection(
     const std::string &surrounding_text,
     const std::string &selected_text,
-    uint cursor_pos,
-    uint *anchor_pos) {
+    unsigned cursor_pos,
+    unsigned *anchor_pos) {
   DCHECK(anchor_pos);
 
   if (surrounding_text.empty()) {
@@ -196,8 +196,8 @@ bool GetSurroundingText(FcitxInstance* instance,
         return false;
     }
 
-    uint cursor_pos = 0;
-    uint anchor_pos = 0;
+    unsigned cursor_pos = 0;
+    unsigned anchor_pos = 0;
     char* str = NULL;
 
     if (!FcitxInstanceGetSurroundingText(instance, ic, &str, &cursor_pos, &anchor_pos)) {
@@ -211,7 +211,7 @@ bool GetSurroundingText(FcitxInstance* instance,
         const char* primary = NULL;
 
         if ((primary = FcitxClipboardGetPrimarySelection(instance, NULL)) != NULL) {
-            uint new_anchor_pos = 0;
+            unsigned new_anchor_pos = 0;
             const std::string primary_text(primary);
             if (SurroundingTextUtil::GetAnchorPosFromSelection(
                 surrounding_text, primary_text,

--- a/src/unix/fcitx/surrounding_text_util.h
+++ b/src/unix/fcitx/surrounding_text_util.h
@@ -55,7 +55,7 @@ class SurroundingTextUtil {
   // Returns true when neither |abs(delta)| nor |-delta| does not cause
   // integer overflow, that is, |delta| is in a safe range.
   // Returns false otherwise.
-  static bool GetSafeDelta(uint from, uint to, int32 *delta);
+  static bool GetSafeDelta(unsigned from, unsigned to, int32 *delta);
 
   // Returns true if
   // 1. |surrounding_text| contains |selected_text|
@@ -71,8 +71,8 @@ class SurroundingTextUtil {
   static bool GetAnchorPosFromSelection(
       const std::string &surrounding_text,
       const std::string &selected_text,
-      uint cursor_pos,
-      uint *anchor_pos);
+      unsigned cursor_pos,
+      unsigned *anchor_pos);
 
  private:
   DISALLOW_IMPLICIT_CONSTRUCTORS(SurroundingTextUtil);

--- a/src/unix/fcitx5/surrounding_text_util.cc
+++ b/src/unix/fcitx5/surrounding_text_util.cc
@@ -43,10 +43,10 @@ namespace fcitx {
 
 using namespace mozc;
 
-bool SurroundingTextUtil::GetSafeDelta(uint from, uint to, int32 *delta) {
+bool SurroundingTextUtil::GetSafeDelta(unsigned from, unsigned to, int32 *delta) {
   DCHECK(delta);
 
-  static_assert(sizeof(int64) >= sizeof(uint),
+  static_assert(sizeof(int64) >= sizeof(unsigned),
                 "int64 must be sufficient to store a guint value.");
   static_assert(sizeof(int64) == sizeof(llabs(0)),
                 "|llabs(0)| must returns a 64-bit integer.");
@@ -110,8 +110,8 @@ bool StartsWith(ConstChar32Iterator *iter, ConstChar32Iterator *prefix_iter) {
 // Otherwise returns false.
 bool SearchAnchorPosForward(const std::string &surrounding_text,
                             const std::string &selected_text,
-                            size_t selected_chars_len, uint cursor_pos,
-                            uint *anchor_pos) {
+                            size_t selected_chars_len, unsigned cursor_pos,
+                            unsigned *anchor_pos) {
   ConstChar32Iterator iter(surrounding_text);
   // Move |iter| to cursor pos.
   if (!Skip(&iter, cursor_pos)) {
@@ -131,15 +131,15 @@ bool SearchAnchorPosForward(const std::string &surrounding_text,
 // Otherwise returns false.
 bool SearchAnchorPosBackward(const std::string &surrounding_text,
                              const std::string &selected_text,
-                             size_t selected_chars_len, uint cursor_pos,
-                             uint *anchor_pos) {
+                             size_t selected_chars_len, unsigned cursor_pos,
+                             unsigned *anchor_pos) {
   if (cursor_pos < selected_chars_len) {
     return false;
   }
 
   ConstChar32Iterator iter(surrounding_text);
   // Skip |iter| to (potential) anchor pos.
-  const uint skip_count = cursor_pos - selected_chars_len;
+  const unsigned skip_count = cursor_pos - selected_chars_len;
   DCHECK_LE(skip_count, cursor_pos);
   if (!Skip(&iter, skip_count)) {
     return false;
@@ -157,7 +157,7 @@ bool SearchAnchorPosBackward(const std::string &surrounding_text,
 
 bool SurroundingTextUtil::GetAnchorPosFromSelection(
     const std::string &surrounding_text, const std::string &selected_text,
-    uint cursor_pos, uint *anchor_pos) {
+    unsigned cursor_pos, unsigned *anchor_pos) {
   DCHECK(anchor_pos);
 
   if (surrounding_text.empty()) {
@@ -187,13 +187,13 @@ bool GetSurroundingText(InputContext *ic, SurroundingTextInfo *info,
   }
 
   const auto surrounding_text = ic->surroundingText().text();
-  uint cursor_pos = ic->surroundingText().cursor();
-  uint anchor_pos = ic->surroundingText().anchor();
+  unsigned cursor_pos = ic->surroundingText().cursor();
+  unsigned anchor_pos = ic->surroundingText().anchor();
 
   if (cursor_pos == anchor_pos && clipboard) {
     std::string primary = clipboard->call<IClipboard::primary>(ic);
     if (!primary.empty()) {
-      uint new_anchor_pos = 0;
+      unsigned new_anchor_pos = 0;
       if (SurroundingTextUtil::GetAnchorPosFromSelection(
               surrounding_text, primary, cursor_pos, &new_anchor_pos)) {
         anchor_pos = new_anchor_pos;

--- a/src/unix/fcitx5/surrounding_text_util.h
+++ b/src/unix/fcitx5/surrounding_text_util.h
@@ -56,7 +56,7 @@ class SurroundingTextUtil {
   // Returns true when neither |abs(delta)| nor |-delta| does not cause
   // integer overflow, that is, |delta| is in a safe range.
   // Returns false otherwise.
-  static bool GetSafeDelta(uint from, uint to, int32 *delta);
+  static bool GetSafeDelta(unsigned from, unsigned to, int32 *delta);
 
   // Returns true if
   // 1. |surrounding_text| contains |selected_text|
@@ -71,7 +71,7 @@ class SurroundingTextUtil {
   // Otherwise returns false.
   static bool GetAnchorPosFromSelection(const std::string &surrounding_text,
                                         const std::string &selected_text,
-                                        uint cursor_pos, uint *anchor_pos);
+                                        unsigned cursor_pos, unsigned *anchor_pos);
 
  private:
   DISALLOW_IMPLICIT_CONSTRUCTORS(SurroundingTextUtil);


### PR DESCRIPTION
uint is not standard type and (as its name suggested,) it's usually
typedef-ed to unsigned int.

While I strongly believe that those occurence should be "size_t",
I decided to replace with "unsigned" in order to not have any surprising
change in behaviours.

Fix broken build with musl libc.

**Mozc team is not accepting pull requests for files under src/.**

Although Google company policy certainly allows Mozc team to accept pull
requests, to do so Mozc team needs to move all Mozc source files into
`third_party` directory in the Google internal source repository [1].
Doing that without breaking any Google internal project that depends on
Mozc source code requires non-trivial amount of time and engineering
resources that Mozc team cannot afford right now.

Mozc team continues to seek opportunities to address this limitation,
but we are still not ready to accept any pull request due to the above
reason.

[1]: [Open Source at Google - Linuxcon 2016](http://events.linuxfoundation.org/sites/events/files/slides/OSS_at_Google.pdf#page=30)
> ### License Compliance
> - We store all external open source code in a third_party hierarchy,
> along with the licenses for each project. We only allow the use of OSS
> under licenses we can comply with.
> - Use of external open source is not allowed unless it is put in that
> third_party tree.
> - This makes it easier to ensure we are only using software with
licenses that we can abide.
> - This also allows us to generate a list of all licenses used by any
project we build when they are released externally.
