### PR TITLE
Rename Bazel build rules around protobuf (fcitx & fcitx5 targets)

### DIFF
--- a/src/unix/fcitx/BUILD
+++ b/src/unix/fcitx/BUILD
@@ -17,7 +17,7 @@ cc_library_mozc(
         "//base:util",
         "//client:client",
         "//session:ime_switch_util",
-        "//protocol:commands_proto",
+        "//protocol:commands_cc_proto",
     ]
 )
 
@@ -40,7 +40,7 @@ cc_library_mozc(
         "//base:process",
         "//base:run_level",
         "//base:util",
-        "//protocol:commands_proto",
+        "//protocol:commands_cc_proto",
         "//client:client_interface",
     ],
 )
@@ -58,8 +58,8 @@ cc_library_mozc(
     deps = [
         "//base:logging",
         "//base:port",
-        "//protocol:config_proto",
-        "//protocol:commands_proto",
+        "//protocol:config_cc_proto",
+        "//protocol:commands_cc_proto",
     ],
 )
 

--- a/src/unix/fcitx5/BUILD
+++ b/src/unix/fcitx5/BUILD
@@ -17,7 +17,7 @@ cc_library_mozc(
         "//base:util",
         "//client:client",
         "//session:ime_switch_util",
-        "//protocol:commands_proto",
+        "//protocol:commands_cc_proto",
     ]
 )
 
@@ -46,7 +46,7 @@ cc_library_mozc(
         "//base:process",
         "//base:run_level",
         "//base:util",
-        "//protocol:commands_proto",
+        "//protocol:commands_cc_proto",
         "//client:client_interface",
         "@fcitx5//:fcitx5",
     ],
@@ -65,8 +65,8 @@ cc_library_mozc(
     deps = [
         "//base:logging",
         "//base:port",
-        "//protocol:config_proto",
-        "//protocol:commands_proto",
+        "//protocol:config_cc_proto",
+        "//protocol:commands_cc_proto",
         "@fcitx5//:fcitx5",
     ],
 )


### PR DESCRIPTION
Commit 7654223979067e3c5ae52ea238d43880c5508f85 has introduced new names for several of the Bazel build rules, which breaks the fcitx & fcitx5 targets. This fix makes them compatible with the new naming scheme.

**Mozc team is not accepting pull requests for files under src/.**

Although Google company policy certainly allows Mozc team to accept pull
requests, to do so Mozc team needs to move all Mozc source files into
`third_party` directory in the Google internal source repository [1].
Doing that without breaking any Google internal project that depends on
Mozc source code requires non-trivial amount of time and engineering
resources that Mozc team cannot afford right now.

Mozc team continues to seek opportunities to address this limitation,
but we are still not ready to accept any pull request due to the above
reason.

[1]: [Open Source at Google - Linuxcon 2016](http://events.linuxfoundation.org/sites/events/files/slides/OSS_at_Google.pdf#page=30)
> ### License Compliance
> - We store all external open source code in a third_party hierarchy,
> along with the licenses for each project. We only allow the use of OSS
> under licenses we can comply with.
> - Use of external open source is not allowed unless it is put in that
> third_party tree.
> - This makes it easier to ensure we are only using software with
licenses that we can abide.
> - This also allows us to generate a list of all licenses used by any
project we build when they are released externally.
