### PR TITLE
Fix support for fcitx installed in prefix

### DIFF
--- a/src/pkg_config_repository.bzl
+++ b/src/pkg_config_repository.bzl
@@ -103,7 +103,7 @@ def _pkg_config_repository_impl(repo_ctx):
         "hdrs": _make_strlist([item + "/**" for item in includes]),
         "copts": _make_strlist(_exec_pkg_config(repo_ctx, "--cflags-only-other")),
         "includes": _make_strlist(includes),
-        "linkopts": _make_strlist(_exec_pkg_config(repo_ctx, "--libs-only-l")),
+        "linkopts": _make_strlist(_exec_pkg_config(repo_ctx, "--libs")),
     }
     build_file_data = BUILD_TEMPLATE.format(**data)
 


### PR DESCRIPTION
This fixes building this mozc fork when fcitx5 is installed in prefix using CMake.

# Before

```
ERROR: /home/home/CLionProjects/mozc/src/unix/fcitx5/BUILD:90:15: Linking unix/fcitx5/fcitx5-mozc.so failed: (Exit 1): gcc failed: error executing command (from target //unix/fcitx5:fcitx5-mozc.so) /usr/bin/gcc @bazel-out/k8-opt/bin/unix/fcitx5/fcitx5-mozc.so-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
/usr/bin/ld.gold: error: cannot find -lFcitx5Config
/usr/bin/ld.gold: error: cannot find -lFcitx5Core
/usr/bin/ld.gold: error: cannot find -lFcitx5Utils
collect2: error: ld returned 1 exit status
INFO: Elapsed time: 80.291s, Critical Path: 39.71s
INFO: 1316 processes: 126 internal, 1190 linux-sandbox.
FAILED: Build did NOT complete successfully
```

# After

```
INFO: Elapsed time: 81.380s, Critical Path: 38.43s
INFO: 1316 processes: 125 internal, 1191 linux-sandbox.
INFO: Build completed successfully, 1316 total actions
```