### PR TITLE
Fix install_fcitx5_data when system sh is dash

### DIFF
--- a/scripts/install_fcitx5_data
+++ b/scripts/install_fcitx5_data
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PREFIX="${PREFIX:-/usr}"
 


### PR DESCRIPTION
Ubuntu has `dash` instead of `bash` as `/bin/sh` because it wanted to speed up system startup. This causes incompatibilities when we assume that `sh` is `bash` and continue to use bashisms. This problem is solved by explicitly requesting `bash` for the one script that needs it.

# Before

```
$ ../scripts/install_fcitx5_bazel
../scripts/install_fcitx5_data: 8: Bad substitution
$
```

# After

```
$ ../scripts/install_fcitx5_bazel
$
```