### PR TITLE
Support linking against fcitx installed in prefix

### DIFF
--- a/scripts/build_fcitx5_bazel
+++ b/scripts/build_fcitx5_bazel
@@ -1,3 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-bazel build -c opt --copt=-fPIC  --config oss_linux  unix/fcitx5:fcitx5-mozc.so server:mozc_server gui/tool:mozc_tool
+declare -a ARGS=(-c opt --copt=-fPIC --config oss_linux unix/fcitx5:fcitx5-mozc.so server:mozc_server gui/tool:mozc_tool)
+if [ -n "$PREFIX" ]; then
+  ARGS+=(--linkopt=-L"$PREFIX"/lib)
+fi
+bazel build "${ARGS[@]}"


### PR DESCRIPTION
This is the alternative solution @wengxt suggested in #31. That PR was to fix bazel failing linkage of the final output against fcitx5 shared libraries installed in a prefix.

Upstream restricts many contributions and demands testing on more platforms. Also, `scripts/install_fcitx5_{bazel,data,icons}` respects the `PREFIX`, so it's only natural to make `build_fcitx5` consistent with them.