### PR TITLE
Do not rely on implicit string_view to string conversion

### DIFF
--- a/src/unix/fcitx5/surrounding_text_util.cc
+++ b/src/unix/fcitx5/surrounding_text_util.cc
@@ -210,12 +210,12 @@ bool GetSurroundingText(InputContext *ic, SurroundingTextInfo *info,
 
   const size_t selection_start = std::min(cursor_pos, anchor_pos);
   const size_t selection_length = std::abs(info->relative_selected_length);
-  info->preceding_text =
-      Util::Utf8SubString(surrounding_text, 0, selection_start);
-  info->selection_text =
-      Util::Utf8SubString(surrounding_text, selection_start, selection_length);
-  info->following_text =
-      Util::Utf8SubString(surrounding_text, selection_start + selection_length);
+  info->preceding_text = std::string(
+      Util::Utf8SubString(surrounding_text, 0, selection_start));
+  info->selection_text = std::string(
+      Util::Utf8SubString(surrounding_text, selection_start, selection_length));
+  info->following_text = std::string(
+      Util::Utf8SubString(surrounding_text, selection_start + selection_length));
   return true;
 }
 


### PR DESCRIPTION
This fixes an error when compiled with a copy of `abseil-cpp` that was compiled as C++14.

**Description**

When trying to compile this project [in Fedora Linux](https://src.fedoraproject.org/rpms/fcitx5-mozc) against a system copy `abseil-cpp` (version 20230125.3) that was compiled as C++14 (instead of C++17), an error occurs:

```
../../unix/fcitx5/surrounding_text_util.cc: In function ‘bool fcitx::GetSurroundingText(InputContext*, SurroundingTextInfo*, AddonInstance*)’:
../../unix/fcitx5/surrounding_text_util.cc:216:68: error: no match for ‘operator=’ (operand types are ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} and ‘absl::lts_20230125::string_view’)
  216 |       Util::Utf8SubString(surrounding_text_view, 0, selection_start);
      |                                                                    ^
In file included from /usr/include/c++/13/string:54,
                 from /usr/include/Fcitx5/Core/fcitx/inputcontext.h:14,
                 from /builddir/build/BUILD/mozc/src/unix/fcitx5/surrounding_text_util.h:33,
                 from ../../unix/fcitx5/surrounding_text_util.cc:30:
/usr/include/c++/13/bits/basic_string.h:935:8: note: candidate: ‘template<class _Tp> std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_If_sv<_Tp, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&> std::__cxx11::basic_string<_CharT,
 _Traits, _Alloc>::operator=(const _Tp&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’
  935 |        operator=(const _Tp& __svt)
      |        ^~~~~~~~
```

I can’t easily explain why this is working when `abseil-cpp` is compiled as C++17, but it’s clear that the problem I’m encountering is in the implicit conversion from the `absl::string_view` returned by `Util::Utf8SubString` to the `std::string` needed for the assignment to a `SurroundingTextInfo` member. It’s my understanding that this isn’t *supposed* to be implicit, because it creates a copy.

Anyway, using the `std::string` constructor to create an copy solves the problem, and we can expect the copy from a temporary string to the struct member should be elided.

**Issue IDs**

*N/A*

**Steps to test new behaviors (if any)**

*N/A: behavior should not change, except that a compiler error will not occur in some situations*

**Additional context**

*N/A*