### PR TITLE
VLOG -> MOZC_VLOG

### DIFF
--- a/src/unix/fcitx/BUILD
+++ b/src/unix/fcitx/BUILD
@@ -15,6 +15,7 @@ mozc_cc_library(
         ":surrounding_text_util",
         "//base:port",
         "//base:util",
+        "//base:vlog",
         "//client:client",
         "//protocol:commands_cc_proto",
     ]
@@ -38,6 +39,7 @@ mozc_cc_library(
         "//base:process",
         "//base:run_level",
         "//base:util",
+        "//base:vlog",
         "//protocol:commands_cc_proto",
         "//client:client_interface",
     ],
@@ -56,6 +58,7 @@ mozc_cc_library(
     deps = [
         "//base:logging",
         "//base:port",
+        "//base:vlog",
         "//protocol:config_cc_proto",
         "//protocol:commands_cc_proto",
         "@fcitx//:fcitx",
@@ -74,6 +77,7 @@ mozc_cc_library(
         "//base:util",
         "//base:logging",
         "//base:port",
+        "//base:vlog",
         "@fcitx//:fcitx",
     ],
 )

--- a/src/unix/fcitx/fcitx_key_event_handler.cc
+++ b/src/unix/fcitx/fcitx_key_event_handler.cc
@@ -33,6 +33,7 @@
 #include <map>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/singleton.h"
 
 namespace mozc {

--- a/src/unix/fcitx/fcitx_key_translator.cc
+++ b/src/unix/fcitx/fcitx_key_translator.cc
@@ -35,6 +35,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 
 namespace mozc {
 namespace {
@@ -341,7 +342,7 @@ bool KeyTranslator::Translate(FcitxKeySym keyval,
              it != kSpecialKeyMap->end()) {
     out_event->set_special_key(it->second);
   } else {
-    VLOG(1) << "Unknown keyval: " << keyval;
+    MOZC_VLOG(1) << "Unknown keyval: " << keyval;
     return false;
   }
 

--- a/src/unix/fcitx/fcitx_mozc.cc
+++ b/src/unix/fcitx/fcitx_mozc.cc
@@ -40,6 +40,7 @@
 
 #include "base/const.h"
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/process.h"
 #include "base/util.h"
 #include "base/file_util.h"
@@ -130,7 +131,7 @@ FcitxMozc::FcitxMozc ( FcitxInstance* inst,
         composition_mode_ ( mozc::commands::HIRAGANA )
 {
     // mozc::Logging::SetVerboseLevel(1);
-    VLOG ( 1 ) << "FcitxMozc created.";
+    MOZC_VLOG ( 1 ) << "FcitxMozc created.";
     const bool is_vertical = true;
     parser_->set_use_annotation ( is_vertical );
     InitializeBar();
@@ -140,7 +141,7 @@ FcitxMozc::FcitxMozc ( FcitxInstance* inst,
 
 FcitxMozc::~FcitxMozc()
 {
-    VLOG ( 1 ) << "FcitxMozc destroyed.";
+    MOZC_VLOG ( 1 ) << "FcitxMozc destroyed.";
 }
 
 // This function is called from SCIM framework when users press or release a
@@ -170,7 +171,7 @@ void FcitxMozc::select_candidate ( FcitxCandidateWord* candWord )
         LOG ( ERROR ) << "The clicked candidate doesn't have unique ID.";
         return;
     }
-    VLOG ( 1 ) << "select_candidate, id=" << *id;
+    MOZC_VLOG ( 1 ) << "select_candidate, id=" << *id;
 
     std::string error;
     mozc::commands::Output raw_response;
@@ -189,7 +190,7 @@ void FcitxMozc::select_candidate ( FcitxCandidateWord* candWord )
 // This function is called from SCIM framework.
 void FcitxMozc::resetim()
 {
-    VLOG ( 1 ) << "resetim";
+    MOZC_VLOG ( 1 ) << "resetim";
     std::string error;
     mozc::commands::Output raw_response;
     if ( connection_->TrySendCommand (
@@ -218,7 +219,7 @@ void FcitxMozc::reset()
 
 bool FcitxMozc::paging(bool prev)
 {
-    VLOG ( 1 ) << "paging";
+    MOZC_VLOG ( 1 ) << "paging";
     std::string error;
     mozc::commands::SessionCommand::CommandType command =
         prev ? mozc::commands::SessionCommand::CONVERT_PREV_PAGE
@@ -236,7 +237,7 @@ bool FcitxMozc::paging(bool prev)
 // This function is called from SCIM framework when the ic gets focus.
 void FcitxMozc::init()
 {
-    VLOG ( 1 ) << "init";
+    MOZC_VLOG ( 1 ) << "init";
     boolean flag = true;
     FcitxInstanceSetContext(instance, CONTEXT_DISABLE_AUTOENG, &flag);
     FcitxInstanceSetContext(instance, CONTEXT_DISABLE_FULLWIDTH, &flag);
@@ -251,7 +252,7 @@ void FcitxMozc::init()
 // This function is called when the ic loses focus.
 void FcitxMozc::focus_out()
 {
-    VLOG ( 1 ) << "focus_out";
+    MOZC_VLOG ( 1 ) << "focus_out";
     std::string error;
     mozc::commands::Output raw_response;
     if ( connection_->TrySendCommand (
@@ -271,7 +272,7 @@ bool FcitxMozc::ParseResponse ( const mozc::commands::Output &raw_response )
     const bool consumed = parser_->ParseResponse ( raw_response, this );
     if ( !consumed )
     {
-        VLOG ( 1 ) << "The input was not consumed by Mozc.";
+        MOZC_VLOG ( 1 ) << "The input was not consumed by Mozc.";
     }
     OpenUrl();
     DrawAll();
@@ -338,7 +339,7 @@ void FcitxMozc::DrawPreeditInfo()
     FcitxMessagesSetMessageCount(clientpreedit, 0);
     if ( preedit_info_.get() )
     {
-        VLOG ( 1 ) << "DrawPreeditInfo: cursor=" << preedit_info_->cursor_pos;
+        MOZC_VLOG ( 1 ) << "DrawPreeditInfo: cursor=" << preedit_info_->cursor_pos;
 
         FcitxInputContext* ic = FcitxInstanceGetCurrentIC(instance);
         boolean supportPreedit = FcitxInstanceICSupportPreedit(instance, ic);
@@ -402,7 +403,7 @@ static const char* GetMozcToolIcon(void* arg)
 
 void FcitxMozc::InitializeBar()
 {
-    VLOG ( 1 ) << "Registering properties";
+    MOZC_VLOG ( 1 ) << "Registering properties";
 
     FcitxUIRegisterComplexStatus(instance, this,
         "mozc-composition-mode",

--- a/src/unix/fcitx/mozc_connection.cc
+++ b/src/unix/fcitx/mozc_connection.cc
@@ -33,6 +33,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/util.h"
 #include "client/client.h"
 #include "ipc/ipc.h"
@@ -60,7 +61,7 @@ MozcConnection::MozcConnection(
     : handler_(new KeyEventHandler),
       preedit_method_(mozc::config::Config::ROMAN),
       client_factory_(client_factory) {
-  VLOG(1) << "MozcConnection is created";
+  MOZC_VLOG(1) << "MozcConnection is created";
   auto client = CreateAndConfigureClient();
   client->SetIPCClientFactory(client_factory_.get());
   client_ = std::move(client);
@@ -68,14 +69,14 @@ MozcConnection::MozcConnection(
   if (client_->EnsureConnection()) {
     UpdatePreeditMethod();
   }
-  VLOG(1)
+  MOZC_VLOG(1)
       << "Current preedit method is "
       << (preedit_method_ == mozc::config::Config::ROMAN ? "Roman" : "Kana");
 }
 
 MozcConnection::~MozcConnection() {
   client_->SyncData();
-  VLOG(1) << "MozcConnection is destroyed";
+  MOZC_VLOG(1) << "MozcConnection is destroyed";
 }
 
 void MozcConnection::UpdatePreeditMethod() {
@@ -103,7 +104,7 @@ bool MozcConnection::TrySendKeyEvent(
   // to establish the server connection.
   if (!client_->EnsureConnection()) {
     *out_error = "EnsureConnection failed";
-    VLOG(1) << "EnsureConnection failed";
+    MOZC_VLOG(1) << "EnsureConnection failed";
     return false;
   }
 
@@ -113,7 +114,7 @@ bool MozcConnection::TrySendKeyEvent(
 
   if ((composition_mode == mozc::commands::DIRECT) &&
       !client_->IsDirectModeCommand(event)) {
-    VLOG(1) << "In DIRECT mode. Not consumed.";
+    MOZC_VLOG(1) << "In DIRECT mode. Not consumed.";
     return false;  // not consumed.
   }
 
@@ -125,13 +126,13 @@ bool MozcConnection::TrySendKeyEvent(
     context.set_following_text(surrounding_text_info.following_text);
   }
 
-  VLOG(1) << "TrySendKeyEvent: " << std::endl << event.DebugString();
+  MOZC_VLOG(1) << "TrySendKeyEvent: " << std::endl << event.DebugString();
   if (!client_->SendKeyWithContext(event, context, out)) {
     *out_error = "SendKey failed";
-    VLOG(1) << "ERROR";
+    MOZC_VLOG(1) << "ERROR";
     return false;
   }
-  VLOG(1) << "OK: " << std::endl << out->DebugString();
+  MOZC_VLOG(1) << "OK: " << std::endl << out->DebugString();
   return true;
 }
 
@@ -184,13 +185,13 @@ bool MozcConnection::TrySendRawCommand(
     const mozc::commands::SessionCommand& command,
     mozc::commands::Output *out,
     std::string *out_error) const {
-  VLOG(1) << "TrySendRawCommand: " << std::endl << command.DebugString();
+  MOZC_VLOG(1) << "TrySendRawCommand: " << std::endl << command.DebugString();
   if (!client_->SendCommand(command, out)) {
     *out_error = "SendCommand failed";
-    VLOG(1) << "ERROR";
+    MOZC_VLOG(1) << "ERROR";
     return false;
   }
-  VLOG(1) << "OK: " << std::endl << out->DebugString();
+  MOZC_VLOG(1) << "OK: " << std::endl << out->DebugString();
   return true;
 }
 

--- a/src/unix/fcitx/mozc_response_parser.cc
+++ b/src/unix/fcitx/mozc_response_parser.cc
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/util.h"
 #include "protocol/commands.pb.h"
 #include "unix/fcitx/fcitx_mozc.h"
@@ -162,7 +163,7 @@ void MozcResponseParser::ExecuteCallback(const mozc::commands::Output& response,
         range->set_length(abs(surrounding_text_info.relative_selected_length));
     }
 
-    VLOG(1) << "New output" << new_output.DebugString();
+    MOZC_VLOG(1) << "New output" << new_output.DebugString();
 
     ParseResponse(new_output, fcitx_mozc);
 }

--- a/src/unix/fcitx/surrounding_text_util.cc
+++ b/src/unix/fcitx/surrounding_text_util.cc
@@ -40,6 +40,7 @@
 
 #include "base/port.h"
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/util.h"
 
 namespace mozc {

--- a/src/unix/fcitx5/BUILD
+++ b/src/unix/fcitx5/BUILD
@@ -15,6 +15,7 @@ mozc_cc_library(
         ":surrounding_text_util",
         "//base:port",
         "//base:util",
+        "//base:vlog",
         "//client:client",
         "//protocol:commands_cc_proto",
     ]
@@ -55,6 +56,7 @@ mozc_cc_library(
         "//base:process",
         "//base:run_level",
         "//base:util",
+        "//base:vlog",
         "//protocol:commands_cc_proto",
         "//client:client_interface",
         "@fcitx5//:fcitx5",
@@ -74,6 +76,7 @@ mozc_cc_library(
     deps = [
         "//base:logging",
         "//base:port",
+        "//base:vlog",
         "//protocol:config_cc_proto",
         "//protocol:commands_cc_proto",
         "@fcitx5//:fcitx5",
@@ -92,6 +95,7 @@ mozc_cc_library(
         "//base:util",
         "//base:logging",
         "//base:port",
+        "//base:vlog",
         "@fcitx5//:fcitx5",
     ],
 )

--- a/src/unix/fcitx5/fcitx_key_event_handler.cc
+++ b/src/unix/fcitx5/fcitx_key_event_handler.cc
@@ -33,6 +33,7 @@
 #include <map>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/singleton.h"
 
 namespace fcitx {

--- a/src/unix/fcitx5/fcitx_key_translator.cc
+++ b/src/unix/fcitx5/fcitx_key_translator.cc
@@ -31,6 +31,7 @@
 #include "unix/fcitx5/fcitx_key_translator.h"
 
 #include "base/logging.h"
+#include "base/vlog.h"
 
 namespace fcitx {
 using namespace mozc;
@@ -337,7 +338,7 @@ bool KeyTranslator::Translate(KeySym keyval, uint32_t keycode,
              it != kSpecialKeyMap->end()) {
     out_event->set_special_key(it->second);
   } else {
-    VLOG(1) << "Unknown keyval: " << keyval;
+    MOZC_VLOG(1) << "Unknown keyval: " << keyval;
     return false;
   }
 

--- a/src/unix/fcitx5/mozc_connection.cc
+++ b/src/unix/fcitx5/mozc_connection.cc
@@ -33,6 +33,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/util.h"
 #include "client/client.h"
 #include "ipc/ipc.h"
@@ -52,10 +53,10 @@ std::unique_ptr<mozc::client::ClientInterface> CreateAndConfigureClient() {
 
 MozcConnection::MozcConnection()
     : client_factory_(mozc::IPCClientFactory::GetIPCClientFactory()) {
-  VLOG(1) << "MozcConnection is created";
+  MOZC_VLOG(1) << "MozcConnection is created";
 }
 
-MozcConnection::~MozcConnection() { VLOG(1) << "MozcConnection is destroyed"; }
+MozcConnection::~MozcConnection() { MOZC_VLOG(1) << "MozcConnection is destroyed"; }
 
 std::unique_ptr<mozc::client::ClientInterface> MozcConnection::CreateClient() {
   auto client = CreateAndConfigureClient();

--- a/src/unix/fcitx5/mozc_response_parser.cc
+++ b/src/unix/fcitx5/mozc_response_parser.cc
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/process.h"
 #include "base/util.h"
 #include "protocol/commands.pb.h"
@@ -341,7 +342,7 @@ void MozcResponseParser::ExecuteCallback(const mozc::commands::Output &response,
     range->set_length(abs(surrounding_text_info.relative_selected_length));
   }
 
-  VLOG(1) << "New output" << new_output.DebugString();
+  MOZC_VLOG(1) << "New output" << new_output.DebugString();
 
   ParseResponse(new_output, ic);
 }

--- a/src/unix/fcitx5/mozc_state.cc
+++ b/src/unix/fcitx5/mozc_state.cc
@@ -40,6 +40,7 @@
 #include "base/const.h"
 #include "base/file_util.h"
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/process.h"
 #include "base/system_util.h"
 #include "base/util.h"
@@ -55,7 +56,7 @@ namespace fcitx {
 MozcState::MozcState(InputContext* ic, MozcEngine* engine)
     : ic_(ic), engine_(engine), handler_(std::make_unique<KeyEventHandler>()) {
   // mozc::Logging::SetVerboseLevel(1);
-  VLOG(1) << "MozcState created.";
+  MOZC_VLOG(1) << "MozcState created.";
 
   if (GetClient()->EnsureConnection()) {
     UpdatePreeditMethod();
@@ -72,7 +73,7 @@ MozcState::MozcState(InputContext* ic, MozcEngine* engine)
 }
 
 MozcState::~MozcState() {
-  VLOG(1) << "MozcState destroyed.";
+  MOZC_VLOG(1) << "MozcState destroyed.";
 }
 
 void MozcState::UpdatePreeditMethod() {
@@ -114,7 +115,7 @@ bool MozcState::TrySendKeyEvent(
   auto* client = GetClient();
   if (!client->EnsureConnection()) {
     *out_error = "EnsureConnection failed";
-    VLOG(1) << "EnsureConnection failed";
+    MOZC_VLOG(1) << "EnsureConnection failed";
     return false;
   }
 
@@ -125,7 +126,7 @@ bool MozcState::TrySendKeyEvent(
 
   if ((composition_mode == mozc::commands::DIRECT) &&
       !client->IsDirectModeCommand(event)) {
-    VLOG(1) << "In DIRECT mode. Not consumed.";
+    MOZC_VLOG(1) << "In DIRECT mode. Not consumed.";
     return false;  // not consumed.
   }
 
@@ -137,13 +138,13 @@ bool MozcState::TrySendKeyEvent(
     context.set_following_text(surrounding_text_info.following_text);
   }
 
-  VLOG(1) << "TrySendKeyEvent: " << std::endl << event.DebugString();
+  MOZC_VLOG(1) << "TrySendKeyEvent: " << std::endl << event.DebugString();
   if (!client->SendKeyWithContext(event, context, out)) {
     *out_error = "SendKey failed";
-    VLOG(1) << "ERROR";
+    MOZC_VLOG(1) << "ERROR";
     return false;
   }
-  VLOG(1) << "OK: " << std::endl << out->DebugString();
+  MOZC_VLOG(1) << "OK: " << std::endl << out->DebugString();
   return true;
 }
 
@@ -189,13 +190,13 @@ bool MozcState::TrySendCommand(mozc::commands::SessionCommand::CommandType type,
 bool MozcState::TrySendRawCommand(const mozc::commands::SessionCommand& command,
                                   mozc::commands::Output* out,
                                   std::string* out_error) const {
-  VLOG(1) << "TrySendRawCommand: " << std::endl << command.DebugString();
+  MOZC_VLOG(1) << "TrySendRawCommand: " << std::endl << command.DebugString();
   if (!GetClient()->SendCommand(command, out)) {
     *out_error = "SendCommand failed";
-    VLOG(1) << "ERROR";
+    MOZC_VLOG(1) << "ERROR";
     return false;
   }
-  VLOG(1) << "OK: " << std::endl << out->DebugString();
+  MOZC_VLOG(1) << "OK: " << std::endl << out->DebugString();
   return true;
 }
 
@@ -242,7 +243,7 @@ void MozcState::SelectCandidate(int32_t id) {
     LOG(ERROR) << "The clicked candidate doesn't have unique ID.";
     return;
   }
-  VLOG(1) << "select_candidate, id=" << id;
+  MOZC_VLOG(1) << "select_candidate, id=" << id;
 
   std::string error;
   mozc::commands::Output raw_response;
@@ -257,7 +258,7 @@ void MozcState::SelectCandidate(int32_t id) {
 
 // This function is called from SCIM framework.
 void MozcState::Reset() {
-  VLOG(1) << "resetim";
+  MOZC_VLOG(1) << "resetim";
   std::string error;
   mozc::commands::Output raw_response;
   if (TrySendCommand(mozc::commands::SessionCommand::REVERT, &raw_response,
@@ -269,7 +270,7 @@ void MozcState::Reset() {
 }
 
 bool MozcState::Paging(bool prev) {
-  VLOG(1) << "paging";
+  MOZC_VLOG(1) << "paging";
   std::string error;
   mozc::commands::SessionCommand::CommandType command =
       prev ? mozc::commands::SessionCommand::CONVERT_PREV_PAGE
@@ -284,7 +285,7 @@ bool MozcState::Paging(bool prev) {
 
 // This function is called when the ic gets focus.
 void MozcState::FocusIn() {
-  VLOG(1) << "MozcState::FocusIn()";
+  MOZC_VLOG(1) << "MozcState::FocusIn()";
 
   UpdatePreeditMethod();
   DrawAll();
@@ -292,7 +293,7 @@ void MozcState::FocusIn() {
 
 // This function is called when the ic loses focus.
 void MozcState::FocusOut(const InputContextEvent& event) {
-  VLOG(1) << "MozcState::FocusOut()";
+  MOZC_VLOG(1) << "MozcState::FocusOut()";
   std::string error;
   mozc::commands::Output raw_response;
 
@@ -313,7 +314,7 @@ bool MozcState::ParseResponse(const mozc::commands::Output& raw_response) {
   ClearAll();
   const bool consumed = engine_->parser()->ParseResponse(raw_response, ic_);
   if (!consumed) {
-    VLOG(1) << "The input was not consumed by Mozc.";
+    MOZC_VLOG(1) << "The input was not consumed by Mozc.";
   }
   OpenUrl();
   DrawAll();

--- a/src/unix/fcitx5/surrounding_text_util.cc
+++ b/src/unix/fcitx5/surrounding_text_util.cc
@@ -36,6 +36,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/vlog.h"
 #include "base/port.h"
 #include "base/util.h"
 


### PR DESCRIPTION
## Description
Correct VLOG to MOZC_VLOG according to official changes.

## Issue IDs


## Modified code locations
src/unix/fcitx/fcitx_key_translator.cc
src/unix/fcitx/fcitx_mozc.cc
src/unix/fcitx/mozc_connection.cc
src/unix/fcitx/mozc_response_parser.cc
src/unix/fcitx/BUILD
src/unix/fcitx5/fcitx_key_translator.cc
src/unix/fcitx5/mozc_connection.cc
src/unix/fcitx5/mozc_response_parser.cc
src/unix/fcitx5/mozc_state.cc
src/unix/fcitx5/BUILD

## Confirmation of the acceptable code locations
Yes
