### PR TITLE
Update BUILD

### DIFF
--- a/src/unix/fcitx5/BUILD
+++ b/src/unix/fcitx5/BUILD
@@ -77,6 +77,7 @@ mozc_cc_library(
         "//base:logging",
         "//base:port",
         "//base:vlog",
+        "//base:singleton",
         "//protocol:config_cc_proto",
         "//protocol:commands_cc_proto",
         "@fcitx5//:fcitx5",


### PR DESCRIPTION
For bazel, fix dependencies in fcitx_key_event_handler.cc. Added relationship with base/singleton.h.

## Description
Errors occur at build time due to insufficient description of bazel.

## Issue IDs

## Steps to test new behaviors (if any)
bazel build --config oss_linux --compilation_mode opt unix/fcitx5:fcitx5-mozc.so

## Additional context
