### PR TITLE
Remove obsolete //base:logging from unix/fcitx

### DIFF
--- a/src/unix/fcitx/BUILD
+++ b/src/unix/fcitx/BUILD
@@ -18,6 +18,7 @@ mozc_cc_library(
         "//base:vlog",
         "//client:client",
         "//protocol:commands_cc_proto",
+	"@com_google_absl//absl/log:check",
     ]
 )
 
@@ -42,6 +43,7 @@ mozc_cc_library(
         "//base:vlog",
         "//protocol:commands_cc_proto",
         "//client:client_interface",
+	"@com_google_absl//absl/log:check",
     ],
 )
 
@@ -56,12 +58,12 @@ mozc_cc_library(
         "fcitx_key_translator.h",
     ],
     deps = [
-        "//base:logging",
         "//base:port",
+	"//base:singleton",
         "//base:vlog",
         "//protocol:config_cc_proto",
         "//protocol:commands_cc_proto",
-        "@fcitx//:fcitx",
+	"@com_google_absl//absl/log:check",
     ],
 )
 
@@ -75,10 +77,9 @@ mozc_cc_library(
     ],
     deps = [
         "//base:util",
-        "//base:logging",
         "//base:port",
         "//base:vlog",
-        "@fcitx//:fcitx",
+	"@com_google_absl//absl/log:check",
     ],
 )
 
@@ -88,7 +89,6 @@ mozc_cc_binary(
     deps = [
         ":fcitx_mozc",
         "//base:init_mozc",
-        "@fcitx//:fcitx",
     ],
     local_defines = [
         'LOCALEDIR=\\"/usr/share/locale\\"',

--- a/src/unix/fcitx/fcitx_key_event_handler.cc
+++ b/src/unix/fcitx/fcitx_key_event_handler.cc
@@ -32,7 +32,7 @@
 
 #include <map>
 
-#include "base/logging.h"
+#include "absl/log/check.h"
 #include "base/vlog.h"
 #include "base/singleton.h"
 

--- a/src/unix/fcitx/fcitx_key_translator.cc
+++ b/src/unix/fcitx/fcitx_key_translator.cc
@@ -34,7 +34,7 @@
 #include <set>
 #include <string>
 
-#include "base/logging.h"
+#include "absl/log/check.h"
 #include "base/vlog.h"
 
 namespace mozc {

--- a/src/unix/fcitx/fcitx_mozc.cc
+++ b/src/unix/fcitx/fcitx_mozc.cc
@@ -38,8 +38,8 @@
 // Resolve macro naming conflict with absl.
 #undef InvokeFunction
 
+#include "absl/log/check.h"
 #include "base/const.h"
-#include "base/logging.h"
 #include "base/vlog.h"
 #include "base/process.h"
 #include "base/util.h"

--- a/src/unix/fcitx/mozc_connection.cc
+++ b/src/unix/fcitx/mozc_connection.cc
@@ -32,7 +32,7 @@
 
 #include <string>
 
-#include "base/logging.h"
+#include "absl/log/check.h"
 #include "base/vlog.h"
 #include "base/util.h"
 #include "client/client.h"

--- a/src/unix/fcitx/mozc_response_parser.cc
+++ b/src/unix/fcitx/mozc_response_parser.cc
@@ -33,7 +33,7 @@
 #include <string>
 #include <vector>
 
-#include "base/logging.h"
+#include "absl/log/check.h"
 #include "base/vlog.h"
 #include "base/util.h"
 #include "protocol/commands.pb.h"

--- a/src/unix/fcitx/surrounding_text_util.cc
+++ b/src/unix/fcitx/surrounding_text_util.cc
@@ -38,8 +38,8 @@
 #undef InvokeFunction
 #endif
 
+#include "absl/log/check.h"
 #include "base/port.h"
-#include "base/logging.h"
 #include "base/vlog.h"
 #include "base/util.h"
 


### PR DESCRIPTION
## Description
Remove obsolete //base:logging from unix/fcitx
