### PR TITLE
Fix paging button doesn't update highlight

### DIFF
--- a/src/unix/fcitx5/mozc_state.cc
+++ b/src/unix/fcitx5/mozc_state.cc
@@ -310,8 +310,7 @@ bool MozcState::Paging(bool prev) {
            : mozc::commands::SessionCommand::CONVERT_NEXT_PAGE;
   mozc::commands::Output raw_response;
   if (TrySendCommand(command, &raw_response, &error)) {
-    engine_->parser()->ParseResponse(raw_response, ic_);
-    return true;
+    return ParseResponse(raw_response);
   }
   return false;
 }


### PR DESCRIPTION
Pressing PageDown updates preedit and number in `[ hightlight index / total number of candidates]`, while clicking paging button doesn't. The behaviors should be the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page navigation now correctly updates the interface, clears relevant state, and opens pending links when applicable.
  * Page-turn actions now report their actual handled status instead of always indicating success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->