### PR TITLE
Rename SWITCH_INPUT_MODE command to SWITCH_COMPOSITION_MODE in Mozc API.

### DIFF
--- a/src/unix/fcitx/fcitx_mozc.cc
+++ b/src/unix/fcitx/fcitx_mozc.cc
@@ -308,7 +308,7 @@ void FcitxMozc::SetCompositionMode ( mozc::commands::CompositionMode mode )
 
 void FcitxMozc::SendCompositionMode(mozc::commands::CompositionMode mode)
 {
-    // Send the SWITCH_INPUT_MODE command.
+    // Send the SWITCH_COMPOSITION_MODE command.
     std::string error;
     mozc::commands::Output raw_response;
     if (connection_->TrySendCompositionMode(

--- a/src/unix/fcitx/mozc_connection.cc
+++ b/src/unix/fcitx/mozc_connection.cc
@@ -157,7 +157,7 @@ bool MozcConnection::TrySendCompositionMode(
     command.set_type(mozc::commands::SessionCommand::TURN_OFF_IME);
     command.set_composition_mode(old_mode);
   } else {
-    command.set_type(mozc::commands::SessionCommand::SWITCH_INPUT_MODE);
+    command.set_type(mozc::commands::SessionCommand::SWITCH_COMPOSITION_MODE);
     command.set_composition_mode(mode);
   }
   return TrySendRawCommand(command, out, out_error);

--- a/src/unix/fcitx/mozc_response_parser.cc
+++ b/src/unix/fcitx/mozc_response_parser.cc
@@ -180,7 +180,7 @@ bool MozcResponseParser::ParseResponse(const mozc::commands::Output &response,
     UpdateDeletionRange(response, fcitx_mozc);
 
     // We should check the mode field first since the response for a
-    // SWITCH_INPUT_MODE request only contains mode and id fields.
+    // SWITCH_COMPOSITION_MODE request only contains mode and id fields.
     if (response.has_mode()) {
         fcitx_mozc->SetCompositionMode(response.mode());
     }

--- a/src/unix/fcitx5/mozc_response_parser.cc
+++ b/src/unix/fcitx5/mozc_response_parser.cc
@@ -368,7 +368,7 @@ bool MozcResponseParser::ParseResponse(const mozc::commands::Output &response,
   UpdateDeletionRange(response, ic);
 
   // We should check the mode field first since the response for a
-  // SWITCH_INPUT_MODE request only contains mode and id fields.
+  // SWITCH_COMPOSITION_MODE request only contains mode and id fields.
   if (response.has_mode()) {
     mozc_state->SetCompositionMode(
         response.mode(), !engine_->deactivating() &&

--- a/src/unix/fcitx5/mozc_state.cc
+++ b/src/unix/fcitx5/mozc_state.cc
@@ -171,7 +171,7 @@ bool MozcState::TrySendCompositionMode(mozc::commands::CompositionMode mode,
     command.set_type(mozc::commands::SessionCommand::TURN_OFF_IME);
     command.set_composition_mode(composition_mode_);
   } else {
-    command.set_type(mozc::commands::SessionCommand::SWITCH_INPUT_MODE);
+    command.set_type(mozc::commands::SessionCommand::SWITCH_COMPOSITION_MODE);
     command.set_composition_mode(mode);
   }
   return TrySendRawCommand(command, out, out_error);
@@ -379,7 +379,7 @@ void MozcState::SetCompositionMode(mozc::commands::CompositionMode mode,
 }
 
 void MozcState::SendCompositionMode(mozc::commands::CompositionMode mode) {
-  // Send the SWITCH_INPUT_MODE command.
+  // Send the SWITCH_COMPOSITION_MODE command.
   std::string error;
   mozc::commands::Output raw_response;
   if (TrySendCompositionMode(mode, &raw_response, &error)) {


### PR DESCRIPTION
commit cbb4844a7fc9b0304c9daa886e4c288a45ba7fb1

    Rename SWITCH_INPUT_MODE command to SWITCH_COMPOSITION_MODE in Mozc API.

    This helps improve terminology consistency & reduce confusion in Mozc API. The command operates on a CompositionMode param, whereas "input mode" is the typical user-facing label (e.g. on CrOS) for the unrelated concept known internally as PreeditMethod (romaji vs kana).

    Related terminology at layers immediately adjacent to the Mozc API, on both client & Mozc-internal sides, is adapted accordingly.

    PiperOrigin-RevId: 836610651

## Description
Build Error

## Issue IDs

## Steps to test new behaviors (if any)

## Additional context
```
ERROR: /__w/mozc-arch/mozc-arch/archlinux/src/mozc/src/unix/fcitx5/BUILD.bazel:98:16: Compiling unix/fcitx5/mozc_state.cc failed: (Exit 1): clang-21 failed: error executing CppCompile command (from target //unix/fcitx5:mozc_engine) 
  (cd /github/workspace/.cache/bazel/_bazel_nonroot/b289bbdc948a309d60870d085d2ae5e8/sandbox/processwrapper-sandbox/1184/execroot/_main && \
  exec env - \
    PATH=/github/workspace/.cache/bazelisk/downloads/sha256/3453736dc067a9b923f3066aad378282cd864830d9ad135a45ac9c1ebc47bbae/bin:/usr/local/sbin:/usr/local/bin:/usr/bin \
    *** \
  /usr/bin/clang-21 -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-std=c++17' -MD -MF bazel-out/k8-opt/bin/unix/fcitx5/_objs/mozc_engine/mozc_state.pic.d '-frandom-seed=bazel-out/k8-opt/bin/unix/fcitx5/_objs/mozc_engine/mozc_state.pic.o' -fPIC -DMOZC_BUILD -iquote . -iquote bazel-out/k8-opt/bin -iquote external/abseil-cpp+ -iquote bazel-out/k8-opt/bin/external/abseil-cpp+ -iquote external/protobuf+ -iquote bazel-out/k8-opt/bin/external/protobuf+ -iquote external/zlib+ -iquote bazel-out/k8-opt/bin/external/zlib+ -iquote external/+_repo_rules2+fcitx5 -iquote bazel-out/k8-opt/bin/external/+_repo_rules2+fcitx5 -Ibazel-out/k8-opt/bin/external/protobuf+/src/google/protobuf/_virtual_includes/protobuf -Ibazel-out/k8-opt/bin/external/protobuf+/src/google/protobuf/_virtual_includes/internal_visibility -Ibazel-out/k8-opt/bin/
# Configuration: 7c3b58f08bef92f686283878702fb4f8e0faf1c5008df588138d85eb689c5cf3
# Execution platform: @@platforms//host:host
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
unix/fcitx5/mozc_state.cc:174:54: error: no member named 'SWITCH_INPUT_MODE' in 'mozc::commands::SessionCommand'
  174 |     command.set_type(mozc::commands::SessionCommand::SWITCH_INPUT_MODE);
      |                                                      ^~~~~~~~~~~~~~~~~
1 error generated.
```
