### PR TITLE
Assign properties icon to config_dialog

### DIFF
--- a/src/unix/fcitx5/mozc_engine.cc
+++ b/src/unix/fcitx5/mozc_engine.cc
@@ -182,7 +182,7 @@ MozcEngine::MozcEngine(Instance* instance)
   instance_->userInterfaceManager().registerAction("mozc-tool-config",
                                                    &configToolAction_);
   configToolAction_.setShortText(_("Configuration Tool"));
-  configToolAction_.setIcon("fcitx_mozc_tool");
+  configToolAction_.setIcon("fcitx_mozc_properties");
   configToolAction_.connect<SimpleAction::Activated>([](InputContext*) {
     mozc::Process::SpawnMozcProcess("mozc_tool", "--mode=config_dialog");
   });


### PR DESCRIPTION

## Description

Before:

fcitx_mozc_tool is assigned both of toolAction
and configToolAction. Their role is different, but same icon resource is assigned to them. Thus fcitx_mozc_properties is not used at all.

After:

Assign toolAction to fcitx_mozc_tool (same as before, wrench image), configToolAction to fcitx_mozc_properties (wheel/gear image). After that, role and actual image will match.

## Issue IDs

N/A

## Steps to test new behaviors (if any)

* Apply patch and build fcitx5-mozc.
* Enable fcitx5-mozc and show indicator.
* Ensure tool menu icon and configuration tool icon are rendered correctly.


## Additional context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Mozc configuration tool to use the `fcitx_mozc_properties` icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->