### PR TITLE
split annotation to CandidateWord comment

### DIFF
--- a/src/unix/fcitx5/mozc_response_parser.cc
+++ b/src/unix/fcitx5/mozc_response_parser.cc
@@ -76,13 +76,16 @@ uint32_t GetCursorPosition(const mozc::commands::Output& response) {
 }
 
 std::string CreateDescriptionString(const std::string& description) {
-  return " [" + description + "]";
+  return "[" + description + "]";
 }
 
 class MozcCandidateWord final : public CandidateWord {
  public:
-  MozcCandidateWord(int id, std::string text, MozcEngine* engine)
-      : CandidateWord(Text(std::move(text))), id_(id), engine_(engine) {}
+  MozcCandidateWord(int id, std::string text, std::string comment,
+                    MozcEngine* engine)
+      : CandidateWord(Text(std::move(text))), id_(id), engine_(engine) {
+    setComment(Text(std::move(comment)));
+  }
 
   void select(InputContext* inputContext) const override {
     MozcState* mozc_state = engine_->mozcState(inputContext);
@@ -150,6 +153,7 @@ class MozcCandidateList final : public CandidateList,
       const uint32_t index = candidate.index();
 
       std::string value;
+      std::string comment;
       if (use_annotation && candidate.has_annotation() &&
           candidate.annotation().has_prefix()) {
         value = candidate.annotation().prefix();
@@ -162,8 +166,8 @@ class MozcCandidateList final : public CandidateList,
       if (use_annotation && candidate.has_annotation() &&
           candidate.annotation().has_description()) {
         // Display descriptions ([HALF][KATAKANA], [GREEK], [Black square],
-        // etc).
-        value += CreateDescriptionString(candidate.annotation().description());
+        // etc.) as candidate comments.
+        comment = CreateDescriptionString(candidate.annotation().description());
       }
 
       const bool is_current =
@@ -189,7 +193,7 @@ class MozcCandidateList final : public CandidateList,
             std::string msg = _("Press %s to show usages.");
             msg = stringutils::replaceAll(msg, "%s",
                                           engine_->config().expand->toString());
-            value += CreateDescriptionString(msg);
+            comment += CreateDescriptionString(msg);
           }
         }
       }
@@ -207,8 +211,8 @@ class MozcCandidateList final : public CandidateList,
         id = candidate.id();
         DCHECK_NE(kBadCandidateId, id) << "Unexpected id is passed.";
       }
-      candidateWords_.emplace_back(
-          std::make_unique<MozcCandidateWord>(id, value, engine));
+      candidateWords_.emplace_back(std::make_unique<MozcCandidateWord>(
+          id, std::move(value), std::move(comment), engine));
     }
   }
 

--- a/src/unix/fcitx5/mozc_response_parser.cc
+++ b/src/unix/fcitx5/mozc_response_parser.cc
@@ -75,8 +75,12 @@ uint32_t GetCursorPosition(const mozc::commands::Output& response) {
   return response.preedit().cursor();
 }
 
-std::string CreateDescriptionString(const std::string& description) {
-  return "[" + description + "]";
+void AppendDescriptionString(std::string& comment,
+                             const std::string& description) {
+  if (!comment.empty()) {
+    comment += " ";
+  }
+  comment.append("[").append(description).append("]");
 }
 
 class MozcCandidateWord final : public CandidateWord {
@@ -167,7 +171,7 @@ class MozcCandidateList final : public CandidateList,
           candidate.annotation().has_description()) {
         // Display descriptions ([HALF][KATAKANA], [GREEK], [Black square],
         // etc.) as candidate comments.
-        comment = CreateDescriptionString(candidate.annotation().description());
+        AppendDescriptionString(comment, candidate.annotation().description());
       }
 
       const bool is_current =
@@ -193,7 +197,7 @@ class MozcCandidateList final : public CandidateList,
             std::string msg = _("Press %s to show usages.");
             msg = stringutils::replaceAll(msg, "%s",
                                           engine_->config().expand->toString());
-            comment += CreateDescriptionString(msg);
+            AppendDescriptionString(comment, msg);
           }
         }
       }


### PR DESCRIPTION
multi-line information is not affected.

<img width="259" height="370" alt="" src="https://github.com/user-attachments/assets/7544c52b-7aad-454e-a0cc-b787ef8e0673" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Candidate annotations and usage hotkey messages now appear as separate comments instead of being appended to candidate text.
  - Improved candidate description formatting by removing unnecessary leading spacing.
  - Candidate information is now presented more clearly, keeping the main candidate text distinct from supporting annotations and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->