### PR TITLE
fix Escape after Control+Alt+H

### DIFF
--- a/src/unix/fcitx5/mozc_state.cc
+++ b/src/unix/fcitx5/mozc_state.cc
@@ -212,8 +212,13 @@ bool MozcState::ProcessKeyEvent(KeySym sym, uint32_t keycode, KeyStates state,
 
     if (normalized_key.check(Key(FcitxKey_Escape))) {
       displayUsage_ = false;
-      ProcessKeyEvent(FcitxKey_VoidSymbol, 0, KeyState::NoState, layout_is_jp,
-                      false);
+      std::string error;
+      mozc::commands::Output raw_response;
+      if (TrySendCommand(mozc::commands::SessionCommand::NONE, &raw_response,
+                         &error)) {
+        return ParseResponse(raw_response);
+      }
+      displayUsage_ = true;
     }
     return true;
   }


### PR DESCRIPTION
Set `Expand Usage` to `Hotkey`, then type `mizu` and move highlight to 見ず, press Control+Alt+H, then Escape.
Expected: back.
Actual: UI not updated, but `fcitx_key_event_handler.cc:125] Translate failed`. Mozc state is changed, as another Escape will go back twice.